### PR TITLE
Removed `simple` subcommand

### DIFF
--- a/Sources/jsonpath/main.swift
+++ b/Sources/jsonpath/main.swift
@@ -6,60 +6,50 @@ import ArgumentParser
 import Sextant
 
 struct jsonpath: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Perform JSONPath queries")
     
-    static var configuration = CommandConfiguration(
-        abstract: "Perform JSONPath queries",
-        subcommands: [
-            Simple.self,
-        ],
-        defaultSubcommand: Simple.self)
+    @Argument(help: "JSONPath query")
+    var query: String
     
-    struct Simple: ParsableCommand {
-        static var configuration = CommandConfiguration(abstract: "Simplified interface to quickly run a JSONPath query against a file")
+    @Argument(help: "input file")
+    var input: String
+    
+    @Flag(name: .customShort("l"),
+          help: "Output the path to the results instead of the results themselves")
+    var printPaths: Bool = false
+    
+    @Flag(name: .customShort("p"),
+          help: "Pretty print the result JSON")
+    var printPretty: Bool = false
+    
+    mutating func run() throws {
         
-        @Argument(help: "JSONPath query")
-        var query: String
+        guard let jsonData = Hitch(contentsOfFile: input) else {
+            throw CleanExit.message("Failed to read file \(input)")
+        }
         
-        @Argument(help: "input file")
-        var input: String
+        let queries: [Hitch] = [
+            Hitch(string: query)
+        ]
         
-        @Flag(name: .customShort("l"),
-              help: "Output the path to the results instead of the results themselves")
-        var printPaths: Bool = false
-        
-        @Flag(name: .customShort("p"),
-              help: "Pretty print the result JSON")
-        var printPretty: Bool = false
-
-        mutating func run() throws {
+        jsonData.parsed { root in
+            guard let root = root else { fatalError("Failed to parse \(input)") }
             
-            guard let jsonData = Hitch(contentsOfFile: input) else {
-                throw CleanExit.message("Failed to read file \(input)")
-            }
-            
-            let queries: [Hitch] = [
-                Hitch(string: query)
-            ]
-            
-            jsonData.parsed { root in
-                guard let root = root else { fatalError("Failed to parse \(input)") }
-                
-                if printPaths {
-                    if let results = root.query(paths: queries) {
-                        let combined = ^[]
-                        for result in results {
-                            combined.append(value: result)
-                        }
-                        print(combined.toHitch(pretty: printPretty))
+            if printPaths {
+                if let results = root.query(paths: queries) {
+                    let combined = ^[]
+                    for result in results {
+                        combined.append(value: result)
                     }
-                } else {
-                    if let results = root.query(elements: queries) {
-                        let combined = ^[]
-                        for result in results {
-                            combined.append(value: result)
-                        }
-                        print(combined.toHitch(pretty: printPretty))
+                    print(combined.toHitch(pretty: printPretty))
+                }
+            } else {
+                if let results = root.query(elements: queries) {
+                    let combined = ^[]
+                    for result in results {
+                        combined.append(value: result)
                     }
+                    print(combined.toHitch(pretty: printPretty))
                 }
             }
         }


### PR DESCRIPTION
Got rid of the `simple` subcommand and moved all work directly into the top-level `jsonpath: ParsableCommand`. Since `simple` was the only subcommand, and `jsonpath` itself wasn't doing any work, there was little point to having a command hierarchy. Simplifying the command has the benefit of simplifying the help interface. 

**before:** help only mentioned existence of simple subcommand
``` sh 
% jsonpath -h
OVERVIEW: Perform JSONPath queries

USAGE: jsonpath <subcommand>

OPTIONS:
  -h, --help              Show help information.

SUBCOMMANDS:
  simple (default)        Simplified interface to quickly run a JSONPath query against a file

  See 'jsonpath help <subcommand>' for detailed help.
```

**after:** actual arguments and options are listed
``` sh
% jsonpath -h
OVERVIEW: Simplified interface to quickly run a JSONPath query against a file

USAGE: jsonpath simple <query> <input> [-l] [-p]

ARGUMENTS:
  <query>                 JSONPath query
  <input>                 input file

OPTIONS:
  -l                      Output the path to the results instead of the results themselves
  -p                      Pretty print the result JSON
  -h, --help              Show help information.
```